### PR TITLE
Add content-length header to frames.

### DIFF
--- a/StompClient.pas
+++ b/StompClient.pas
@@ -405,6 +405,10 @@ begin
         h := AHeaders.GetAt(i);
         AFrame.GetHeaders.Add(h.Key, h.Value);
       end;
+
+  // If the frame has some content, then set the length of that content.
+  if (AFrame.ContentLength > 0) then
+    AFrame.GetHeaders.Add('content-length', IntToStr(AFrame.ContentLength));
 end;
 
 procedure TStompClient.Nack(const MessageID, TransactionIdentifier: string);

--- a/StompTypes.pas
+++ b/StompTypes.pas
@@ -63,6 +63,7 @@ type
     procedure SetBody(const Value: string);
     function GetHeaders: IStompHeaders;
     function MessageID: string;
+    function ContentLength: Integer;
   end;
 
   IStompClient = interface
@@ -130,6 +131,7 @@ type
   private
     FCommand: string;
     FBody: string;
+    FContentLength: Integer;
     FHeaders: IStompHeaders;
     procedure SetHeaders(const Value: IStompHeaders);
     function GetCommand: string;
@@ -147,6 +149,7 @@ type
     // otherwise, return Value;
     function Output: string;
     function MessageID: string;
+    function ContentLength: Integer;
     property Headers: IStompHeaders read GetHeaders write SetHeaders;
   end;
 
@@ -273,6 +276,7 @@ begin
   FHeaders := TStompHeaders.Create;
   self.FCommand := '';
   self.FBody := '';
+  self.FContentLength := 0;
 end;
 
 destructor TStompFrame.Destroy;
@@ -305,9 +309,15 @@ begin
   Result := FCommand + LINE_END + FHeaders.Output + LINE_END + FBody + COMMAND_END;
 end;
 
+function TStompFrame.ContentLength: Integer;
+begin
+  Result := FContentLength;
+end;
+
 procedure TStompFrame.SetBody(const Value: string);
 begin
   FBody := Value;
+  FContentLength := Length(TEncoding.UTF8.GetBytes(FBody));
 end;
 
 procedure TStompFrame.SetCommand(const Value: string);


### PR DESCRIPTION
The stomp specification states (from 1.0 onwards)

It is recommended that SEND frames include a content-length header which is a byte count for the length of the message body. If a content-length header is included, this number of bytes should be read, regardless of whether or not there are null characters in the body. The frame still needs to be terminated with a null byte and if a content-length is not specified, the first null byte encountered signals the end of the frame.

This change calculates the length in bytes of the body of message and sets the corresponding header on the frame which sends that message.  This allows the body of the message to contain null characters.
